### PR TITLE
portscan.cache shouldn't be stored in github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 *~
+portscan.cache

--- a/portscan.cache
+++ b/portscan.cache
@@ -1,1 +1,0 @@
-/dev/ttyUSB0


### PR DESCRIPTION
As the name implies, it's only a cache file, and the real serial device name is likely to be different on different computers (especially if you already have other serial->USB adaptors plugged in)
